### PR TITLE
Scene Attribute and UIToolkit support

### DIFF
--- a/SceneRefAttribute.cs
+++ b/SceneRefAttribute.cs
@@ -28,6 +28,11 @@ namespace KBCore.Refs
         /// using GetComponent(s)InChildren()
         /// </summary>
         Child = 2,
+        /// <summary>
+        /// Scene looks for the reference anywhere in the scene
+        /// using GameObject.FindAnyObjectByType() and GameObject.FindObjectsOfType()
+        /// </summary>
+        Scene = 4,
     }
     
     /// <summary>
@@ -114,6 +119,18 @@ namespace KBCore.Refs
     {
         public ChildAttribute(Flag flags = Flag.None) 
             : base(RefLoc.Child, flags: flags)
+        {}
+    }
+    
+    /// <summary>
+    /// Scene looks for the reference anywhere in the scene
+    /// using GameObject.FindAnyObjectByType() and GameObject.FindObjectsOfType()
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field)]
+    public class SceneAttribute : SceneRefAttribute
+    {
+        public SceneAttribute(Flag flags = Flag.None) 
+            : base(RefLoc.Scene, flags: flags)
         {}
     }
 }

--- a/SceneRefAttributePropertyDrawer.cs
+++ b/SceneRefAttributePropertyDrawer.cs
@@ -1,8 +1,12 @@
-#if UNITY_EDITOR
+﻿#if UNITY_EDITOR
 using UnityEditor;
 using UnityEngine;
 using System;
 using System.Linq;
+#if UNITY_2022_2_OR_NEWER
+using UnityEngine.UIElements;
+using UnityEditor.UIElements;
+#endif
 
 namespace KBCore.Refs
 {
@@ -24,6 +28,77 @@ namespace KBCore.Refs
         private string _typeName;
 
         private SceneRefAttribute _sceneRefAttribute => (SceneRefAttribute) attribute;
+
+// unity 2022.2 makes UIToolkit the default for inspectors
+#if UNITY_2022_2_OR_NEWER
+        public readonly static string sceneRefClass = "kbcore-refs-sceneref";
+
+        private PropertyField _propertyField;
+        private HelpBox _helpBox;
+        private InspectorElement _inspectorElement;
+        private SerializedProperty _serializedProperty;
+
+        public override VisualElement CreatePropertyGUI(SerializedProperty property)
+        {
+            this._serializedProperty = property;
+            this.Initialize(property);
+
+            VisualElement root = new VisualElement();
+            root.AddToClassList(sceneRefClass);
+
+            this._helpBox = new HelpBox("", HelpBoxMessageType.Error);
+            this._helpBox.style.display = DisplayStyle.None;
+            root.Add(this._helpBox);
+
+            this._propertyField = new PropertyField(property);
+            this._propertyField.SetEnabled(false);
+            root.Add(this._propertyField);
+
+            if (this._canValidateType)
+            {
+                this.UpdateHelpBox();
+                this._propertyField.RegisterCallback<AttachToPanelEvent>(this.OnAttach);
+            }
+            return root;
+        }
+
+        private void OnAttach(AttachToPanelEvent attachToPanelEvent)
+        {
+            this._propertyField.UnregisterCallback<AttachToPanelEvent>(this.OnAttach);
+            this._inspectorElement = this._propertyField.GetFirstAncestorOfType<InspectorElement>();
+            if (this._inspectorElement == null)
+                // not in an inspector, invalid
+                return;
+
+            // subscribe to SerializedPropertyChangeEvent so we can update when the property changes
+            this._inspectorElement.RegisterCallback<SerializedPropertyChangeEvent>(this.OnSerializedPropertyChangeEvent);
+            this._propertyField.RegisterCallback<DetachFromPanelEvent>(this.OnDetach);
+        }
+
+        private void OnDetach(DetachFromPanelEvent detachFromPanelEvent)
+        {
+            // unregister from all callbacks
+            this._propertyField.UnregisterCallback<DetachFromPanelEvent>(this.OnDetach);
+            this._inspectorElement.UnregisterCallback<SerializedPropertyChangeEvent>(this.OnSerializedPropertyChangeEvent);
+            this._serializedProperty = null;
+        }
+
+        private void OnSerializedPropertyChangeEvent(SerializedPropertyChangeEvent changeEvent)
+        {
+            if (changeEvent.changedProperty != this._serializedProperty)
+                return;
+            this.UpdateHelpBox();
+        }
+
+        private void UpdateHelpBox()
+        {
+            bool isSatisfied = this.IsSatisfied(this._serializedProperty);
+            this._helpBox.style.display = isSatisfied ? DisplayStyle.None : DisplayStyle.Flex;
+            string message = $"Missing {this._serializedProperty.propertyPath} ({this._typeName}) reference on {this._sceneRefAttribute.Loc}!";
+            this._helpBox.text = message;
+        }
+
+#endif
 
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {

--- a/SceneRefAttributePropertyDrawer.cs
+++ b/SceneRefAttributePropertyDrawer.cs
@@ -14,6 +14,7 @@ namespace KBCore.Refs
     [CustomPropertyDrawer(typeof(SelfAttribute))]
     [CustomPropertyDrawer(typeof(ChildAttribute))]
     [CustomPropertyDrawer(typeof(ParentAttribute))]
+    [CustomPropertyDrawer(typeof(SceneAttribute))]
     public class SceneRefAttributePropertyDrawer : PropertyDrawer
     {
 

--- a/SceneRefAttributeValidator.cs
+++ b/SceneRefAttributeValidator.cs
@@ -138,6 +138,7 @@ namespace KBCore.Refs
             
             bool isArray = fieldType.IsArray;
             bool includeInactive = attr.HasFlags(Flag.IncludeInactive);
+            FindObjectsInactive includeInactiveObjects = includeInactive ? FindObjectsInactive.Include : FindObjectsInactive.Exclude;
             
             Type elementType = fieldType;
             if (isArray)
@@ -171,6 +172,12 @@ namespace KBCore.Refs
                     value = isArray
                         ? c.GetComponentsInChildren(elementType, includeInactive)
                         : c.GetComponentInChildren(elementType, includeInactive);
+                    break;
+                case RefLoc.Scene:
+                    FindObjectsSortMode findObjectsSortMode = FindObjectsSortMode.None;
+                    value = isArray
+                        ? GameObject.FindObjectsByType(elementType, includeInactiveObjects, findObjectsSortMode)
+                        : GameObject.FindAnyObjectByType(elementType, includeInactiveObjects);
                     break;
                 default:
                     throw new Exception($"Unhandled Loc={attr.Loc}");
@@ -275,6 +282,11 @@ namespace KBCore.Refs
                         Debug.LogError($"{c.GetType().Name} requires {field.FieldType.Name} ref '{field.Name}' to be a Child", c.gameObject);
                     break;
                     
+                case RefLoc.Scene:
+                    if (c == null)
+                        Debug.LogError($"{c.GetType().Name} requires {field.FieldType.Name} ref '{field.Name}' to be in the scene", c.gameObject);
+                    break;
+
                 default:
                     throw new Exception($"Unhandled Loc={loc}");
             }


### PR DESCRIPTION
Adds new Scene Attribute
[Scene]
uses GameObject.FindAnyObjectByType() and GameObject.FindObjectsByType() to get a component somewhere in the scene

UIToolkit support
adds UIToolkit version of the PropertyDrawer 
only when using version 2022.2 or greater, as that is when Unity made UIToolkit the default inspector