### PR TITLE
Handle value matching for array types as well

### DIFF
--- a/SceneRefAttributeValidator.cs
+++ b/SceneRefAttributeValidator.cs
@@ -270,7 +270,8 @@ namespace KBCore.Refs
             }
             else
             {
-                if (existingValue != null && value.Equals(existingValue))
+                var valuesAreEqual = isArray ? Enumerable.SequenceEqual((object[])value, (object[])existingValue) : value.Equals(existingValue);
+                if (existingValue != null && valuesAreEqual)
                     return existingValue;
                 field.SetValue(c, value);
             }


### PR DESCRIPTION
Fixes an edge case where equivalent arrays are always re-assigned during validation, dirtying the scene and/or prefab.