### PR TITLE
Fix ValidatedMonoBehaviour no method to override

### DIFF
--- a/ValidatedMonoBehaviour.cs
+++ b/ValidatedMonoBehaviour.cs
@@ -9,6 +9,8 @@ namespace KBCore.Refs
         {
             this.ValidateRefs();
         }
+#else
+        protected virtual void OnValidate() { }
 #endif
     }
 }


### PR DESCRIPTION
Fixes `'Foo.OnValidate()': no suitable method found to override` error for subclasses of ValidatedMonoBehaviours in non-editor contexts