### PR TITLE
Only let validation occur in ValidatedMonoBehaviours at edit time

### DIFF
--- a/ValidatedMonoBehaviour.cs
+++ b/ValidatedMonoBehaviour.cs
@@ -7,7 +7,8 @@ namespace KBCore.Refs
 #if UNITY_EDITOR
         protected virtual void OnValidate()
         {
-            this.ValidateRefs();
+            if (!Application.isPlaying)
+                this.ValidateRefs();
         }
 #else
         protected virtual void OnValidate() { }

--- a/ValidatedMonoBehaviour.cs
+++ b/ValidatedMonoBehaviour.cs
@@ -7,7 +7,7 @@ namespace KBCore.Refs
 #if UNITY_EDITOR
         protected virtual void OnValidate()
         {
-            if (!Application.isPlaying)
+            if (!Application.isPlaying || Time.frameCount == 0)
                 this.ValidateRefs();
         }
 #else


### PR DESCRIPTION
Currently, when using AddComponent to something that's a ValidatedMonoBehaviour in play mode, it throws errors for every marked field, since AddComponent calls OnValidate and none of the references exist yet. This PR will make ValidatedMonoBehaviours only call Validate if the editor is not in play mode.