### PR TITLE
Add PropertyDrawer for InterfaceRefs

### DIFF
--- a/InterfaceRefPropertyDrawer.cs
+++ b/InterfaceRefPropertyDrawer.cs
@@ -1,0 +1,30 @@
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEngine;
+using System;
+using System.Linq;
+#if UNITY_2022_2_OR_NEWER
+using UnityEngine.UIElements;
+using UnityEditor.UIElements;
+#endif
+
+namespace KBCore.Refs
+{
+    [CustomPropertyDrawer(typeof(InterfaceRef<>))]
+    public class InterfaceRefPropertyDrawer : PropertyDrawer
+    {
+// unity 2022.2 makes UIToolkit the default for inspectors
+#if UNITY_2022_2_OR_NEWER
+        public override VisualElement CreatePropertyGUI(SerializedProperty property)
+        {
+            return new PropertyField(property.FindPropertyRelative("_implementer"), property.displayName);
+        }
+#endif
+
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUI.PropertyField(position, property.FindPropertyRelative("_implementer"), label, true);
+        }
+    }
+}
+#endif

--- a/InterfaceRefPropertyDrawer.cs.meta
+++ b/InterfaceRefPropertyDrawer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 7ecbe362b68d4fe38d756ce0bee2464f
+timeCreated: 1683488518


### PR DESCRIPTION
Adds a PropertyDrawer so that Unity displays InterfaceRef's implementer properties directly instead of in a foldout