### PR TITLE
Let Anywhere InterfaceRefs get components on objects when needed

### DIFF
--- a/SceneRefAttributeValidator.cs
+++ b/SceneRefAttributeValidator.cs
@@ -217,7 +217,7 @@ namespace KBCore.Refs
             switch (attr.Loc)
             {
                 case RefLoc.Anywhere:
-                    if (typeof(ISerializableRef).IsAssignableFrom(isArray ? fieldType.GetElementType() : fieldType))
+                    if (isArray ? typeof(ISerializableRef).IsAssignableFrom(fieldType.GetElementType()) : iSerializable != null)
                         value = isArray
                             ? (existingValue as ISerializableRef[])?.Select(existingRef => GetComponentIfWrongType(existingRef.SerializedObject, elementType)).ToArray()
                             : GetComponentIfWrongType(existingValue, elementType);


### PR DESCRIPTION
This allows Anywhere InterfaceRefs to get the appropriate component on other GameObjects if it's the wrong type. This lets you drag GameObjects from the inspector onto the field instead of opening a second panel to drag a specific component.

This also pretties up how InterfaceRefs are handled in arrays and printed in general.