### PR TITLE
Validate GameObject for Anywhere

### DIFF
--- a/SceneRefAttributeValidator.cs
+++ b/SceneRefAttributeValidator.cs
@@ -349,7 +349,10 @@ namespace KBCore.Refs
                     ValidateRefLocation(loc, c, field, valueC);
                     break;
                 case ScriptableObject valueSO:
-                    ValidateRefLocation(loc, c, field, valueSO);
+                    ValidateRefLocationAnywhere(loc, c, field, valueSO);
+                    break;
+                case GameObject valueGO:
+                    ValidateRefLocationAnywhere(loc, c, field, valueGO);
                     break;
                 default:
                     throw new Exception($"{c.GetType().Name} has unexpected reference type {refObj?.GetType().Name}");
@@ -389,7 +392,7 @@ namespace KBCore.Refs
         }
 
         // ReSharper disable once UnusedParameter.Local
-        private static void ValidateRefLocation(RefLoc loc, Component c, FieldInfo field, ScriptableObject refObj)
+        private static void ValidateRefLocationAnywhere(RefLoc loc, Component c, FieldInfo field, Object refObj)
         {
             switch (loc)
             {


### PR DESCRIPTION
This validates for GameObjects in the same way as ScriptableObjects, for things like prefabs. It only includes Anywhere, and while technically it could also include Self and the other locations, that doesn't seem particularly useful since it would be the same as asking for the self's Transform.