### PR TITLE
Fixed version of conditional compilation

### DIFF
--- a/KBCore.Refs.asmdef
+++ b/KBCore.Refs.asmdef
@@ -9,6 +9,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "Unity",
+            "expression": "2021.3.18f",
+            "define": "UNITY_2021_3_18_OR_NEWER"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/SceneRefAttributeValidator.cs
+++ b/SceneRefAttributeValidator.cs
@@ -50,7 +50,7 @@ namespace KBCore.Refs
                         continue;
                     }
 
-#if UNITY_2020_3_OR_NEWER
+#if UNITY_2021_3_18_OR_NEWER
                     Object[] objects = Object.FindObjectsByType(scriptType, FindObjectsInactive.Include, FindObjectsSortMode.InstanceID);
 #elif UNITY_2020_1_OR_NEWER
                     Object[] objects = Object.FindObjectsOfType(scriptType, true);
@@ -653,7 +653,7 @@ namespace KBCore.Refs
         {
             bool isUnityType = elementType.IsSubclassOf(typeof(Object));
             
-#if UNITY_2020_3_OR_NEWER
+#if UNITY_2021_3_18_OR_NEWER
             if (isUnityType)
                 return isCollection
                     ? (object)Object.FindObjectsByType(elementType, includeInactive ? FindObjectsInactive.Include : FindObjectsInactive.Exclude, FindObjectsSortMode.InstanceID)


### PR DESCRIPTION
When I tried to use this package in Unity `2021.3.15f` I got many errors because of missing definitions.
According to the [release notes](https://unity.com/de/releases/editor/whats-new/2021.3.18#release-notes) the function `Object.FindObjectsByType()` and similar functions that utilize the `InstanceID` where introduced in `2021.3.18f`.
I fixed this problem by adjusted the version of the conditional compilations.

Thank you for creating this package.