### PR TITLE
Allow manually overriding the found item without validating location

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ private ParticleSystem[] _particles;
 - `ExcludeSelf` only affects `Parent` and `Child`, and determines whether components on this `GameObject` are included in the results. By default, components on this `GameObject` are included.
 - `Editable` only affects `Parent`, `Child` and `Scene`, and allows you to edit the resulting reference. This is useful, for example, if you have two children who would satisfy a reference but you want to manually select which reference is used. 
 - `Filter` allows you to implement custom logic to filter references. See **Filters** below.
-
+- `EditableAnywhere` has the same effect as `Editable` but will not validate the supplied reference. This allows you to manually specify a reference with an automatic fallback.
 ### Filters
 
 This project also provides support for filtering references based on custom logic. 

--- a/SceneRefAttribute.cs
+++ b/SceneRefAttribute.cs
@@ -65,7 +65,7 @@ namespace KBCore.Refs
         /// <summary>
         /// Allows the user to manually set the reference and does not validate the location if manually set
         /// </summary>
-        Overridable = 1 << 4 | Editable
+        EditableAnywhere = 1 << 4 | Editable
     }
     
     /// <summary>

--- a/SceneRefAttribute.cs
+++ b/SceneRefAttribute.cs
@@ -62,6 +62,11 @@ namespace KBCore.Refs
         /// Excludes components on current GameObject from search(only applies to Child and Parent).
         /// </summary>
         ExcludeSelf = 1 << 3,
+        
+        /// <summary>
+        /// Allows the user to manually set the reference and does not validate the location if manually set
+        /// </summary>
+        Overridable = 1 << 4 | Editable
     }
     
     /// <summary>

--- a/SceneRefAttribute.cs
+++ b/SceneRefAttribute.cs
@@ -62,7 +62,6 @@ namespace KBCore.Refs
         /// Excludes components on current GameObject from search(only applies to Child and Parent).
         /// </summary>
         ExcludeSelf = 1 << 3,
-        
         /// <summary>
         /// Allows the user to manually set the reference and does not validate the location if manually set
         /// </summary>

--- a/SceneRefAttributeValidator.cs
+++ b/SceneRefAttributeValidator.cs
@@ -431,7 +431,7 @@ namespace KBCore.Refs
             {
                 value = ser.SerializedObject;
             }
-            
+
             if (IsEmptyOrNull(value, isCollection))
             {
                 if (attr.HasFlags(Flag.Optional))

--- a/SceneRefAttributeValidator.cs
+++ b/SceneRefAttributeValidator.cs
@@ -425,12 +425,13 @@ namespace KBCore.Refs
         {
             Type fieldType = field.FieldType;
             bool isCollection = IsCollectionType(fieldType, out bool _, out bool _);
+            bool isOverridable = attr.HasFlags(Flag.Overridable);
 
             if (value is ISerializableRef ser)
             {
                 value = ser.SerializedObject;
             }
-
+            
             if (IsEmptyOrNull(value, isCollection))
             {
                 if (attr.HasFlags(Flag.Optional))
@@ -461,6 +462,9 @@ namespace KBCore.Refs
                     
                     if (o != null)
                     {
+                        if (isOverridable)
+                            continue;
+                        
                         if (attr.HasFlags(Flag.ExcludeSelf) && o is Component valueC &&
                             valueC.gameObject == c.gameObject)
                             Debug.LogError($"{c.GetType().Name} {elementType?.Name}[] ref '{field.Name}' cannot contain component from the same GameObject", c.gameObject);
@@ -477,6 +481,9 @@ namespace KBCore.Refs
             }
             else
             {
+                if (isOverridable)
+                    return true;
+                
                 if (attr.HasFlags(Flag.ExcludeSelf) && value is Component valueC && valueC.gameObject == c.gameObject)
                     Debug.LogError($"{c.GetType().Name} {fieldType.Name} ref '{field.Name}' cannot be on the same GameObject", c.gameObject);
 

--- a/SceneRefAttributeValidator.cs
+++ b/SceneRefAttributeValidator.cs
@@ -425,7 +425,7 @@ namespace KBCore.Refs
         {
             Type fieldType = field.FieldType;
             bool isCollection = IsCollectionType(fieldType, out bool _, out bool _);
-            bool isOverridable = attr.HasFlags(Flag.Overridable);
+            bool isOverridable = attr.HasFlags(Flag.EditableAnywhere);
 
             if (value is ISerializableRef ser)
             {


### PR DESCRIPTION
I wanted a way to be able to manually set a reference that complied with the data type without adhering to the location attribute, essentially using `Self`, `Child`, etc as fallbacks or default values, but not enforcing those relationships when manually assigned. Setting the `Overridable` flag automatically sets the editable flag.

I've added an `Overridable` flag though I'm not in love with the name of the flag, and bypassed some of the validation logic when this flag is set.

Example usage would be something like:
`[SerializeField, Child(Flag.ExcludeSelf | Flag.Overridable)] private MyClass myClass;`